### PR TITLE
Fix mounting path extension in GH Action

### DIFF
--- a/.github/workflows/integration-tests.yml
+++ b/.github/workflows/integration-tests.yml
@@ -46,7 +46,7 @@ jobs:
           docker run -d --name mediawiki \
             --network "mw-net" \
             -p 8080:80 \
-            -v "${{ github.workspace }}:/var/www/html/extensions/Attachment" \
+            -v "${{ github.workspace }}:/var/www/html/extensions/Attachments" \
             mediawiki:$MW_VERSION
           sleep 5
 


### PR DESCRIPTION
Made a small oopsie by not testing the integration tests using Github Actions in the PR that adds integration testing.