### PR TITLE
Fix Minerva Neue with a new workaround

### DIFF
--- a/extension.json
+++ b/extension.json
@@ -1,6 +1,6 @@
 {
 	"name": "Attachments",
-	"version": "1.0.0",
+	"version": "1.0.1",
 	"author": [
 		"Gittenburg",
 		"Wryck",
@@ -32,7 +32,6 @@
 		"MagicWordwgVariableIDs": "AttachmentsHooks::onMagicWordwgVariableIDs",
 		"ParserGetVariableValueSwitch": "AttachmentsHooks::onParserGetVariableValueSwitch",
 		"SkinTemplateNavigation::Universal": "AttachmentsHooks::onSkinTemplateNavigationUniversal",
-		"MinervaPreRender": "AttachmentsHooks::onMinervaPreRender",
 		"ListDefinedTags": "AttachmentsHooks::onListDefinedTags",
 		"ChangeTagsListActive": "AttachmentsHooks::onListDefinedTags"
 	},

--- a/extension.json
+++ b/extension.json
@@ -45,12 +45,15 @@
 	"ResourceModules": {
 		"ext.attachments.minerva-icon": {
 			"class": "MediaWiki\\ResourceLoader\\ImageModule",
-			"selector": ".mw-ui-icon-minerva-{name}:before",
+			"selector": ".mw-ui-icon-minerva-{name}",
 			"useDataURI": false,
 			"images": {
 				"attachments": "resources/folder.svg",
 				"attach": "resources/file-plus.svg"
 			}
+		},
+		"ext.attachments.minerva-workaround": {
+			"scripts": [ "modules/ext.attachments.minerva-workaround.js" ]
 		}
 	},
 	"ResourceFileModulePaths": {

--- a/includes/AttachmentsHooks.php
+++ b/includes/AttachmentsHooks.php
@@ -72,44 +72,15 @@ class AttachmentsHooks {
 		]);
 
 		if (count($pages)+count($files) > 0 || $attachmentsShowEmptySection){
-			$out->addHTML("<div id=mw-ext-attachments class=mw-parser-output>"); # class for external link icon
+			$out->addHTML("<div id=mw-ext-attachments class=mw-parser-output>");
 			$out->addWikiTextAsInterface("== ".$out->msg('attachments')."==");
-
-			if ($skin->getSkinName() == 'minerva' && substr($out->mBodytext, -6) == '</div>')
-				# hack to make section collapsible (removing </div>)
-				$out->mBodytext = substr($out->mBodytext, 0, -6);
-
 			$out->addHTML($html);
-			if ($skin->getSkinName() == 'minerva')
-				$out->addHTML('</div>');
 			$out->addHTML("</div>");
 		}
 		if ($skin->getSkinName() == 'minerva')
 			$out->addModules('ext.attachments.minerva-icon');
 	}
-
-	public static function onMinervaPreRender( MinervaTemplate $tpl ) {
-		if (!Attachments::isViewingApplicablePage($tpl->getSkin()) || Attachments::hasExtURL($tpl->getSkin()->getTitle()))
-			return;
-
-		$config = MediaWikiServices::getInstance()->getMainConfig();
-		$attachmentsShowEmptySection = $config->get( 'AttachmentsShowEmptySection' );
-		$title = $tpl->getSkin()->getTitle();
-
-		if (Attachments::countAttachments($title) > 0 || $attachmentsShowEmptySection)
-			$tpl->data['page_actions']['attachments'] = [
-				'itemtitle' => $tpl->msg('attachments'),
-				'href' => '#' . Sanitizer::escapeIdForAttribute($tpl->msg('attachments')),
-				'class' => 'mw-ui-icon mw-ui-icon-element mw-ui-icon-minerva-attachments'
-			];
-
-		$tpl->data['page_actions']['attach'] = [
-			'itemtitle' => $tpl->msg('attachments-add-new'),
-			'href' => $title->getLocalURL('action=attach'),
-			'class' => 'mw-ui-icon mw-ui-icon-element mw-ui-icon-minerva-attach'
-		];
-	}
-
+	
 	public static function onSkinTemplateNavigationUniversal( SkinTemplate &$sktemplate, array &$links ) {
 		if (!Attachments::isViewingApplicablePage($sktemplate) || Attachments::hasExtURL($sktemplate->getTitle()))
 			return;
@@ -131,9 +102,10 @@ class AttachmentsHooks {
 		if ($attachmentsShowInViews)
 			$links['views'] = array_slice($links['views'], 0, 2) + [
 				'add_attachment' => [
-					'text'=> $sktemplate->msg('attachments-verb'),
+					'text'=> $sktemplate->msg('attachments-verb')->text(),
 					'href' => $title->getLocalURL('action=attach'),
-					'class' => ''
+					'class' => '',
+					'primary' => true
 				]
 			] + array_slice($links['views'], 2);
 		$links['actions']['add_attachment'] = [
@@ -141,6 +113,7 @@ class AttachmentsHooks {
 			'href' => $title->getLocalURL(['action' => 'attach']),
 			'class' => ''
 		];
+
 		return true;
 	}
 

--- a/includes/AttachmentsHooks.php
+++ b/includes/AttachmentsHooks.php
@@ -16,8 +16,7 @@ class AttachmentsHooks {
 	public static function renderAttach( Parser $parser, $page) {
 		$title = Title::newFromText($page);
 		$parser->getOutput()->setPageProperty(Attachments::getAttachPropname($title), json_encode($title));
-
-		$parser->getOutput()->setPageProperty(Attachments::PROP_ATTACH, true); # allow querying with API:Pageswithprop
+		$parser->getOutput()->setPageProperty(Attachments::PROP_ATTACH, "true"); # allow querying with API:Pageswithprop
 		if ($parser->getTitle()->inNamespace(NS_FILE))
 			# add category for $wgCountCategorizedImagesAsUsed
 			$parser->addTrackingCategory('attachments-category-attached-files', $parser->getTitle());

--- a/includes/AttachmentsHooks.php
+++ b/includes/AttachmentsHooks.php
@@ -76,8 +76,20 @@ class AttachmentsHooks {
 			$out->addHTML($html);
 			$out->addHTML("</div>");
 		}
-		if ($skin->getSkinName() == 'minerva')
+		if ($skin->getSkinName() == 'minerva') {
 			$out->addModules('ext.attachments.minerva-icon');
+
+			// Minerva Neue workaround.
+			// They removed all hooks that could interact with their menu builder, and $links['views'] isn't used (yet).
+			// Delegate the rendering of the 'add attachment' button to JS.
+			$data = [
+				'useWorkaround' => true,
+				'text' => $skin->msg('attachments-verb')->text(),
+				'href' => $title->getLocalURL('action=attach'),
+			];
+			$skin->getOutput()->addJsConfigVars('attachmentsMinervaWorkaround', $data);
+			$skin->getOutput()->addModules('ext.attachments.minerva-workaround');
+		}
 	}
 	
 	public static function onSkinTemplateNavigationUniversal( SkinTemplate &$sktemplate, array &$links ) {
@@ -112,7 +124,6 @@ class AttachmentsHooks {
 			'href' => $title->getLocalURL(['action' => 'attach']),
 			'class' => ''
 		];
-
 		return true;
 	}
 

--- a/modules/ext.attachments.minerva-workaround.js
+++ b/modules/ext.attachments.minerva-workaround.js
@@ -1,0 +1,25 @@
+mw.loader.using('mediawiki.util', function() {
+    const data = mw.config.get( 'attachmentsMinervaWorkaround' );
+    if (data && data.useWorkaround) {
+        const pViews = document.querySelector("#p-views");
+        if (pViews) {
+            const children = pViews.children;
+            const before = children.length > 1 ? children[children.length - 1] : null;
+            if (before) {
+                const attachment = document.createElement("li");
+                attachment.className = "page-actions-menu__list-item";
+                attachment.innerHTML = `
+                    <a role="button" href="${data.href}" data-mw="interface" title="${data.text}" 
+                       class="cdx-button cdx-button--size-large cdx-button--fake-button 
+                              cdx-button--fake-button--enabled cdx-button--icon-only 
+                              cdx-button--weight-quiet">
+                        <span class="mw-ui-icon-minerva-attach" 
+                              style="min-width:20px;min-height:20px;width:1.25rem;height:1.25rem;display:inline-block;background-size:cover;background-position:center;"></span>
+                        <span>${data.text}</span>
+                    </a>
+                `;
+                pViews.insertBefore(attachment, before);
+            }   
+        }
+    }
+});


### PR DESCRIPTION
Removed old incompatible code for Minerva Neue. Newer versions of Minerva also don't have a hook into the menu builder anymore, so the "Add attachment" button needs to be rendered with JS.