### PR TITLE
Add support for MW 1.44

### DIFF
--- a/.github/workflows/integration-tests.yml
+++ b/.github/workflows/integration-tests.yml
@@ -17,7 +17,7 @@ jobs:
     runs-on: ubuntu-24.04
 
     env:
-      MW_VERSION: '1.43'
+      MW_VERSION: '1.44'
 
     steps:
       - name: Checkout code

--- a/README.md
+++ b/README.md
@@ -10,8 +10,8 @@ Attachments is a MediaWiki extension to attach files and external links to pages
 >
 > You can find dedicated branches for supported versions here:
 >
-> - [Attachments for MediaWiki 1.43](https://github.com/vuhuy/Attachments/tree/REL1_43) (current LTS version)
-> - [Attachments for MediaWiki 1.42](https://github.com/vuhuy/Attachments/tree/REL1_42) (legacy stable version)
+> - [Attachments for MediaWiki 1.44](https://github.com/vuhuy/Attachments/tree/REL1_44) (legacy stable version)
+> - [Attachments for MediaWiki 1.43](https://github.com/vuhuy/Attachments/tree/REL1_43) (legacy stable and current LTS version)
 > - [Attachments for MediaWiki 1.39](https://github.com/vuhuy/Attachments/tree/REL1_39) (legacy LTS version)
 
 ## Screenshots

--- a/extension.json
+++ b/extension.json
@@ -11,7 +11,7 @@
 	"license-name": "MIT",
 	"type": "other",
 	"requires": {
-		"MediaWiki": ">= 1.43.0"
+		"MediaWiki": ">= 1.44.0"
 	},
 	"MessagesDirs": {
 		"Attachments": [

--- a/includes/AttachAction.php
+++ b/includes/AttachAction.php
@@ -1,4 +1,5 @@
 <?php
+use MediaWiki\Title\Title;
 use MediaWiki\MediaWikiServices;
 
 class AttachAction extends Action {

--- a/includes/Attachments.php
+++ b/includes/Attachments.php
@@ -1,4 +1,7 @@
 <?php
+use MediaWiki\Category\CategoryViewer;
+use MediaWiki\Linker\Linker;
+use MediaWiki\Title\Title;
 use MediaWiki\MediaWikiServices;
 
 class Attachments {

--- a/includes/AttachmentsHooks.php
+++ b/includes/AttachmentsHooks.php
@@ -1,4 +1,5 @@
 <?php
+use MediaWiki\Title\Title;
 use MediaWiki\MediaWikiServices;
 
 class AttachmentsHooks {

--- a/tests/scripts/run.sh
+++ b/tests/scripts/run.sh
@@ -8,7 +8,7 @@
 #
 # Examples:
 #   ./run_test.sh
-#   ./run_test.sh 1.43
+#   ./run_test.sh 1.44
 
 # Set working directory
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
@@ -28,8 +28,8 @@ cleanup() {
 
 trap cleanup EXIT
 
-# Choose MediaWiki version (default to 1.43)
-MW_VERSION="${1:-1.43}"
+# Choose MediaWiki version (default to 1.44)
+MW_VERSION="${1:-1.44}"
 echo -e "\n\n==> Using MediaWiki version: $MW_VERSION"
 
 # Setup virtual env


### PR DESCRIPTION
MediaWiki 1.44 has been released a few months ago. This fixes all breaking changes with this MediaWiki release.